### PR TITLE
fix: Generate download links for available components

### DIFF
--- a/site/index.markdown
+++ b/site/index.markdown
@@ -60,7 +60,6 @@ layout: full
                                         {% endif %}
                                     {% endfor %}
                                 </div>
-                                <div><a class="install" href="{{ installer.url }}">Download</a></div>
                             {% endfor %}
                         </li>
                     {% endfor %}


### PR DESCRIPTION
This change also disable generating download links for individual .app files as they’re not useful alone.