### PR TITLE
docs: Add some initial API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /_site
 /assets.txt
 /site/_data
-/site/api
+/site/api/v1
 /site/icons
 /site/screenshots
 

--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -11,4 +11,10 @@
     {% if site.author %}<meta name="author" content="{{ site.author }}">{% endif %}
     <link rel="stylesheet" href="{{ "/css/style.css" | absolute_url }}">
     <meta property="og:title" content="{{ site.title }}{% if page.title %} - {{ page.title }}{% endif %}">
+
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.4.0/styles/default.min.css">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.4.0/styles/dark.min.css" media="(prefers-color-scheme: dark)">
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.4.0/highlight.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+
 </head>

--- a/site/_includes/navigation.html
+++ b/site/_includes/navigation.html
@@ -6,6 +6,7 @@
         <li>{% include link.html url="/index/" title="A-Z" %}</li>
         <li>{% include link.html url="/about/" title="About" %}</li>
         <li>{% include link.html url="/contributing/" title="Contributing" %}</li>
+        <li>{% include link.html url="/api/" title="API" %}</li>
         <li><a target="_blank" href="https://github.com/jbmorley/psion-software-index">GitHub</a></li>
     </ul>
 </nav>

--- a/site/api/index.md
+++ b/site/api/index.md
@@ -8,16 +8,19 @@ title: API
 
 The Psion Software Index provides a basic API in the form of static JSON files offering a structured data form of the index.
 
-
 ### Programs
 
-`https://software.psion.info/api/v1/programs.json`
+```txt
+https://software.psion.info/api/v1/programs.json
+```
 
 ### Summary
 
-`https://software.psion.info/api/v1/summary.json`
+```txt
+https://software.psion.info/api/v1/summary.json
+```
 
-Example output:
+#### Example Output
 
 ```
 {
@@ -32,9 +35,11 @@ Example output:
 
 Details of the sources used to compile the index:
 
-`https://software.psion.info/api/v1/sources.json`
+```txt
+https://software.psion.info/api/v1/sources.json
+```
 
-Example output:
+#### Example Output
 
 ```json
 [

--- a/site/api/index.md
+++ b/site/api/index.md
@@ -1,0 +1,57 @@
+---
+title: API
+---
+
+# API
+
+## Version 1
+
+The Psion Software Index provides a basic API in the form of static JSON files offering a structured data form of the index.
+
+
+### Programs
+
+`https://software.psion.info/api/v1/programs.json`
+
+### Summary
+
+`https://software.psion.info/api/v1/summary.json`
+
+Example output:
+
+```
+{
+    "installerCount": 11034,
+    "uidCount": 5757,
+    "versionCount": 6582,
+    "shaCount": 8546
+}
+```
+
+### Sources
+
+Details of the sources used to compile the index:
+
+`https://software.psion.info/api/v1/sources.json`
+
+Example output:
+
+```json
+[
+    {
+        "path": "/home/runner/work/psion-software-index/psion-software-index/_assets/3-libjune-05/3LIBJUNE05.iso",
+        "name": "Psion 3-Lib Shareware Library June 2005",
+        "description": "CD of the Psion 3-Lib\u00a0Shareware\u00a0library for Psion PDA's\u00a0",
+        "url": "https://archive.org/download/3-libjune-05/3LIBJUNE05.iso",
+        "html_url": "https://archive.org/details/3-libjune-05"
+    },
+    {
+        "path": "/home/runner/work/psion-software-index/psion-software-index/_assets/diamond_mako/Mako.iso",
+        "name": "Diamond Mako CD",
+        "description": "<div>Original CD for Diamond Mako (Psion Revo Plus).</div><div><br /></div><div>This CD contains many programs to help you make better use of your Diamond Mako.\u00a0</div><div><br /></div><div><div>-----</div>Here is the original disk image in NRG (Nero) format and the converted to ISO version file</div>",
+        "url": "https://archive.org/download/diamond_mako/Mako.iso",
+        "html_url": "https://archive.org/details/diamond_mako"
+    }
+]
+
+```

--- a/tools/indexer.py
+++ b/tools/indexer.py
@@ -583,8 +583,7 @@ def overlay(library):
     data_output_path = os.path.join(library.output_directory, "_data")
     screenshots_output_path = os.path.join(library.output_directory, "screenshots")
     icons_output_path = os.path.join(library.output_directory, "icons")
-    api_output_path = os.path.join(library.output_directory, "api")
-    api_v1_output_path = os.path.join(api_output_path, "v1")
+    api_v1_output_path = os.path.join(library.output_directory, "api", "v1")
 
     destination_programs_path = os.path.join(data_output_path, "programs.json")
     destination_sources_path = os.path.join(data_output_path, "sources.json")
@@ -611,8 +610,8 @@ def overlay(library):
         shutil.rmtree(data_output_path)
     if os.path.exists(icons_output_path):
         shutil.rmtree(icons_output_path)
-    if os.path.exists(api_output_path):
-        shutil.rmtree(api_output_path)
+    if os.path.exists(api_v1_output_path):
+        shutil.rmtree(api_v1_output_path)
 
     # Create the output directories if they don't exist.
     os.makedirs(data_output_path, exist_ok=True)


### PR DESCRIPTION
This change adds a page for API documentation and the beginnings of the documentation, referencing the three endpoints and giving some example output.